### PR TITLE
Drop datePatternExpires from ProtectionRequirement requireds

### DIFF
--- a/api-definition.yaml
+++ b/api-definition.yaml
@@ -2605,7 +2605,6 @@ definitions:
     description: 'Identification of the protection patterns to be applied to the record / entity '
     required:
       - pattern
-      - datePatternExpires
       - ProtectionExpiration
     properties:
       pattern:


### PR DESCRIPTION
Would be good to be explicit about how the ProtectionRequirement entity is to be handled. I'd have a crack at
editing the #L2616 description but have not idea how to handle "If no date is provided here, the default expiry 
period for the pattern (as specified by NZRIS) will always be applied."